### PR TITLE
Output directory creation refactor

### DIFF
--- a/CRETA/creta.py
+++ b/CRETA/creta.py
@@ -88,7 +88,9 @@ class creta:
 
         if output_path is None:
             output_path = './extractions/'
-            os.makedirs(output_path)
+            if not os.path.exists(output_path):
+                # only attempt to make the output directory if it doesn't exist
+                os.makedirs(output_path)
             print('Ouput path /extractions/ created.')
         if output_path[-1] != '/': output_path+'/'
 
@@ -771,7 +773,9 @@ class creta:
 
         if output_path is None:
             output_path = './extractions/'
-            os.makedirs(output_path)
+            if not os.path.exists(output_path):
+                # only attempt to make the output directory if it doesn't exist
+                os.makedirs(output_path)
             print('Ouput path /extractions/ created.')
         if output_path[-1] != '/': output_path+'/'
 

--- a/CRETA/creta.py
+++ b/CRETA/creta.py
@@ -38,7 +38,20 @@ class creta:
 
         self.creta_dir = creta_dir
         print('CAFE Region Extraction Tool Automaton (CRETA) initialized')
-    
+
+    def create_output_path(self, opath):
+        """
+        Check for existence of the desired output directory and create it
+        if it doesn't exist
+        """
+        if opath is None:
+            opath = './extractions/'
+            if not os.path.exists(opath):
+                # only attempt to make the output directory if it doesn't exist
+                os.makedirs(opath)
+            print('Ouput path', opath, 'created.')
+        if opath[-1] != '/': opath+'/'
+        return opath
 #%%
     ##### Function for single point extraction                                #####
     ###############################################################################  
@@ -86,13 +99,7 @@ class creta:
         if data_path[-1] != '/': data_path+'/'
         if parfile_path[-1] != '/': parfile_path+'/'
 
-        if output_path is None:
-            output_path = './extractions/'
-            if not os.path.exists(output_path):
-                # only attempt to make the output directory if it doesn't exist
-                os.makedirs(output_path)
-            print('Ouput path /extractions/ created.')
-        if output_path[-1] != '/': output_path+'/'
+        output_path = self.create_output_path(output_path)
 
         if PSFs_path is None:
             PSFs_path = self.creta_dir+'PSFs/'
@@ -771,13 +778,7 @@ class creta:
         if data_path[-1] != '/': data_path+'/'
         if parfile_path[-1] != '/': parfile_path+'/'
 
-        if output_path is None:
-            output_path = './extractions/'
-            if not os.path.exists(output_path):
-                # only attempt to make the output directory if it doesn't exist
-                os.makedirs(output_path)
-            print('Ouput path /extractions/ created.')
-        if output_path[-1] != '/': output_path+'/'
+        output_path = self.create_output_path(output_path)
 
         if PSFs_path is None:
             PSFs_path = self.creta_dir+'PSFs/'


### PR DESCRIPTION
Tanio and Thomas, this change factors out the duplicate code to create the spectral extraction directory into a function in the `CRETA` class. It also adds a check about whether the output directory exists before trying to create the directory. I also modified the output message that had `extractions/` hard-coded; so this should now report the directory name provided by the user.